### PR TITLE
修复拼接 ts 链接时的错误

### DIFF
--- a/index.html
+++ b/index.html
@@ -495,7 +495,6 @@ new Vue({
 
     // 合成URL
     applyURL(targetURL, baseURL) {
-      console.log('target: ' + targetURL + '; baseUrl: ' + baseURL)
       baseURL = baseURL || location.href
       if (targetURL.indexOf('http') === 0) {
         return targetURL

--- a/index.html
+++ b/index.html
@@ -495,6 +495,7 @@ new Vue({
 
     // 合成URL
     applyURL(targetURL, baseURL) {
+      console.log('target: ' + targetURL + '; baseUrl: ' + baseURL)
       baseURL = baseURL || location.href
       if (targetURL.indexOf('http') === 0) {
         return targetURL
@@ -502,9 +503,13 @@ new Vue({
         let domain = baseURL.split('/')
         return domain[0] + '//' + domain[2] + targetURL
       } else {
-        let domain = baseURL.split('/')
+        let params = baseURL.split('?')
+        let domain = params[0].split('/')
         domain.pop()
-        return domain.join('/') + '/' + targetURL
+        if (params.length === 1) {
+          return domain.join('/') + '/' + targetURL
+        }
+        return domain.join('/') + '/' + targetURL + '?' + params[1]
       }
     },
 


### PR DESCRIPTION
当 baseURL 包含 `?` （HTTP GET）参数时，会拼接出不正确的 URL 