### PR TITLE
連結不一定包含 .m3u8

### DIFF
--- a/index-en.html
+++ b/index-en.html
@@ -528,10 +528,6 @@ new Vue({
         alert('Please input url')
         return
       }
-      if (this.url.toLowerCase().indexOf('.m3u8') === -1) {
-        alert('The url is error, please  re-enter')
-        return
-      }
       if (this.downloading) {
         alert('downloading，please wait')
         return

--- a/index.html
+++ b/index.html
@@ -586,10 +586,6 @@ new Vue({
         alert('请输入链接')
         return
       }
-      if (this.url.toLowerCase().indexOf('m3u8') === -1) {
-        alert('链接有误，请重新输入')
-        return
-      }
       if (this.downloading) {
         alert('资源下载中，请稍后')
         return


### PR DESCRIPTION
有些網站的 m3u8 影片連結結尾並不是 .m3u8
可能是 .mp4 或沒有附檔名但實際上檔案內資料內容是 m3u8 格式
所以把不包含 .m3u8 字串就當成無效的判斷移除