### PR TITLE
Update m3u8-downloader.user.js

### DIFF
--- a/m3u8-downloader.user.js
+++ b/m3u8-downloader.user.js
@@ -113,7 +113,7 @@
         //     fileName: url.slice(url.lastIndexOf('/') + 1).split('?')[0],
         //   });
         // }
-        originOpen.call(realXHR, method, url)
+        originOpen.apply(realXHR, arguments)
       }
       return realXHR
     }


### PR DESCRIPTION
fix incorrect overwrite of XHR.open.

See also https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/apply.

If not pass all the arguments down to the original XHR.open, some ajax of jquery would be failed like `async: false` or authentication.

I found this bug due to the `Biometric login` of https://ids.ynu.edu.cn/ isn't always shown if enabled this content script.

After some debugging, I found it's an ajax call with `async: false` not working expected. The xhr.open is overwrited incorrect by this script. The third argument `async` is not passed.

See also the following snapshots.

![image](https://github.com/Momo707577045/m3u8-downloader/assets/2276718/ec108e8c-8431-4d6c-a25d-f5f4cd3f66d2)

![image](https://github.com/Momo707577045/m3u8-downloader/assets/2276718/93e04bea-422c-4f5a-8d82-079915ecd7cd)

https://github.com/Momo707577045/m3u8-downloader/blob/6e4fddc042ee4a765f9f27447fdda87fa2f3e5d2/m3u8-downloader.user.js#L106-L117